### PR TITLE
Read power draw from amd_energy kernel driver on supported AMD CPUs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ s-tui uses [psutil](https://github.com/giampaolo/psutil) to probe hardware infor
 s-tui uses [urwid](https://github.com/urwid/urwid) as a graphical engine. urwid only works with UNIX-like systems
 
 - Power read is supported on Intel Core CPUs of the second generation and newer (Sandy Bridge)
+  and on AMD Family 17h CPUs through the [amd_energy](https://www.kernel.org/doc/html/latest/hwmon/amd_energy.html) driver.
 - s-tui tested to run on Raspberry-Pi 4,3,2,1
 
 ## FAQ

--- a/s_tui/sources/rapl_power_source.py
+++ b/s_tui/sources/rapl_power_source.py
@@ -25,7 +25,7 @@ import time
 import logging
 
 from s_tui.sources.source import Source
-from s_tui.sources.rapl_read import rapl_read
+from s_tui.sources.rapl_read import get_power_reader
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,12 +42,14 @@ class RaplPowerSource(Source):
         self.pallet = ('power light', 'power dark',
                        'power light smooth', 'power dark smooth')
 
-        self.last_probe_time = time.time()
-        self.last_probe = rapl_read()
-        if not self.last_probe:
+        self.reader = get_power_reader()
+        if not self.reader:
             self.is_available = False
             logging.debug("Power reading is not available")
             return
+
+        self.last_probe_time = time.time()
+        self.last_probe = self.reader.read_power()
         self.max_power = 1
         self.last_measurement = [0] * len(self.last_probe)
 
@@ -62,7 +64,7 @@ class RaplPowerSource(Source):
     def update(self):
         if not self.is_available:
             return
-        current_measurement_value = rapl_read()
+        current_measurement_value = self.reader.read_power()
         current_measurement_time = time.time()
 
         for m_idx, _ in enumerate(self.last_probe):

--- a/s_tui/sources/rapl_read.py
+++ b/s_tui/sources/rapl_read.py
@@ -95,7 +95,7 @@ class AMDEnergyReader:
     @staticmethod
     def get_pretty_label(label):
         m = AMDEnergyReader.match_label(label)
-        return f"{m.group(1).capitalize()} {int(m.group(2))}"
+        return "%s %d" % (m.group(1).capitalize(), int(m.group(2)))
 
     def read_power(self):
         ret = []

--- a/s_tui/sources/rapl_read.py
+++ b/s_tui/sources/rapl_read.py
@@ -77,8 +77,6 @@ class AMDEnergyReader:
         inputs.sort(key=lambda x: self.get_input_position(x[0], socket_number))
 
         self.inputs = [(self.get_pretty_label(label), inp) for label, inp in inputs]
-        #for i in range(len(self.inputs)):
-        #    self.inputs[i] = (self.get_pretty_label(self.inputs[i][0]), self.inputs[i][1])
 
     @staticmethod
     def match_label(label):

--- a/s_tui/sources/rapl_read.py
+++ b/s_tui/sources/rapl_read.py
@@ -28,6 +28,7 @@ from s_tui.helper_functions import cat
 
 
 INTER_RAPL_DIR = '/sys/class/powercap/intel-rapl/'
+AMD_ENERGY_DIR_GLOB = '/sys/devices/platform/amd_energy.0/hwmon/hwmon*/'
 MICRO_JOULE_IN_JOULE = 1000000.0
 
 RaplStats = namedtuple('rapl', ['label', 'current', 'max'])
@@ -69,14 +70,16 @@ class RaplReader:
 class AMDEnergyReader:
     def __init__(self):
         inputs = list(zip((cat(filename, binary=False) for filename in sorted(
-                                           glob.glob('/sys/devices/platform/amd_energy.0/hwmon/hwmon*/energy*_label'))),
-                           sorted(glob.glob('/sys/devices/platform/amd_energy.0/hwmon/hwmon*/energy*_input'))))
+            glob.glob(AMD_ENERGY_DIR_GLOB + 'energy*_label'))),
+                          sorted(glob.glob(AMD_ENERGY_DIR_GLOB +
+                                           'energy*_input'))))
 
         # How many socket does the system have?
         socket_number = sum(1 for label, _ in inputs if 'socket' in label)
         inputs.sort(key=lambda x: self.get_input_position(x[0], socket_number))
 
-        self.inputs = [(self.get_pretty_label(label), inp) for label, inp in inputs]
+        self.inputs = \
+            [(self.get_pretty_label(label), inp) for label, inp in inputs]
 
     @staticmethod
     def match_label(label):

--- a/s_tui/sources/rapl_read.py
+++ b/s_tui/sources/rapl_read.py
@@ -69,17 +69,16 @@ class RaplReader:
 
 class AMDEnergyReader:
     def __init__(self):
-        inputs = list(zip((cat(filename, binary=False) for filename in sorted(
-            glob.glob(AMD_ENERGY_DIR_GLOB + 'energy*_label'))),
-                          sorted(glob.glob(AMD_ENERGY_DIR_GLOB +
-                                           'energy*_input'))))
+        self.inputs = list(zip((cat(filename, binary=False) for filename in
+                                sorted(glob.glob(AMD_ENERGY_DIR_GLOB +
+                                                 'energy*_label'))),
+                               sorted(glob.glob(AMD_ENERGY_DIR_GLOB +
+                                                'energy*_input'))))
 
         # How many socket does the system have?
-        socket_number = sum(1 for label, _ in inputs if 'socket' in label)
-        inputs.sort(key=lambda x: self.get_input_position(x[0], socket_number))
-
-        self.inputs = \
-            [(self.get_pretty_label(label), inp) for label, inp in inputs]
+        socket_number = sum(1 for label, _ in self.inputs if 'socket' in label)
+        self.inputs.sort(
+            key=lambda x: self.get_input_position(x[0], socket_number))
 
     @staticmethod
     def match_label(label):
@@ -92,11 +91,6 @@ class AMDEnergyReader:
             return num
         else:
             return num + socket_number
-
-    @staticmethod
-    def get_pretty_label(label):
-        m = AMDEnergyReader.match_label(label)
-        return "%s %d" % (m.group(1).capitalize(), int(m.group(2)))
 
     def read_power(self):
         ret = []


### PR DESCRIPTION
I have tested this on my Ryzen 7 4800HS and Ryzen 9 3950X CPUs on kernel 5.8.0-rc5. The reported numbers are reasonable.
Notice that I have used string interpolation which was introduced in Python 3.6.

Implements #32.

Edit: Previously it was stated that the energy reading works with kernel 5.8.0-rc6. This is not true since the driver now performs more restrictive checks for CPU support (see https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=f28e360f29031fdef8df3a1bcad666243bd6872d)