### PR TITLE
Switched cpu measurement_unit from Mhz to Ghz

### DIFF
--- a/s_tui/sources/freq_source.py
+++ b/s_tui/sources/freq_source.py
@@ -37,7 +37,7 @@ class FreqSource(Source):
         Source.__init__(self)
 
         self.name = 'Frequency'
-        self.measurement_unit = 'MHz'
+        self.measurement_unit = 'GHz'
         self.pallet = ('freq light', 'freq dark',
                        'freq light smooth', 'freq dark smooth')
 


### PR DESCRIPTION
Fixes https://github.com/amanusk/s-tui/issues/186.

I am not sure if the switch to show the unit in GHz was intended or not, but if it was intended, then this fixes the displayed unit.

If s-tui should show the frequency in MHz instead, I am happy to provide more debug output for the problem.