### PR TITLE
Add an option to command line to set refresh_rate at launch

### DIFF
--- a/s_tui/s_tui.py
+++ b/s_tui/s_tui.py
@@ -952,7 +952,7 @@ def get_args():
                         help="High Temperature threshold. Default: 80")
     parser.add_argument('-r', '--refresh-rate', dest="refresh_rate",
                         default="2.0",
-                        help="Refresh rate. Default: 2.0")
+                        help="Refresh rate in seconds. Default: 2.0")
     args = parser.parse_args()
     return args
 

--- a/s_tui/s_tui.py
+++ b/s_tui/s_tui.py
@@ -704,7 +704,7 @@ class GraphController:
         self.script_hooks_enabled = True
         self.script_loader = None
 
-        self.refresh_rate = '2.0'
+        self.refresh_rate = args.refresh_rate
 
         self.smooth_graph_mode = False
 
@@ -950,6 +950,9 @@ def get_args():
     parser.add_argument('-tt', '--t_thresh',
                         default=None,
                         help="High Temperature threshold. Default: 80")
+    parser.add_argument('-r', '--refresh-rate', dest="refresh_rate",
+                        default="2.0",
+                        help="Refresh rate. Default: 2.0")
     args = parser.parse_args()
     return args
 


### PR DESCRIPTION
This pull request adds the possibility to set the refresh rate from the command line, at launch. This can be useful for integrating `s-tui` in an automated workflow. Thanks to the well designed code, only a few changes were necessary.

The default value is still `2.0`. I tested the following:
```console
$ s-tui -r1
$ s-tui -r0.5
$ s-tui -r.5
```
All work as expected.

PS : Thank you for this great monitoring tool !  