### PR TITLE
Remove readme target from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # A make file for creating a s-tui executable.
 # This requires pandoc and pyinstaller
 
-all: stui del readme
+all: stui del
 
 # Create s-tui executable
 stui:


### PR DESCRIPTION
Resolves make exiting with exit code 2 with the following error:

```
make: *** No rule to make target 'readme', needed by 'all'. Stop.
```