### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # A make file for creating a s-tui executable.
 # This requires pandoc and pyinstaller
 
-all: stui del readme
+all: stui del
 
 # Create s-tui executable
 stui:


### PR DESCRIPTION
`make all` currently returns a wrong exit code due to including a missing target, that was present at some point but does not exist anymore, in the Makefile.
This fixes the issue.