### PR TITLE
Bump urwid version setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "Topic :: System :: Monitoring",
     ],
     install_requires=[
-        "urwid>=2.6.1",
+        "urwid>=3.0.2",
         "psutil>=7.0.0",
     ],
 )


### PR DESCRIPTION
I bumped the urwid version in the setup.py file to the latest version that I can install with pip as suggested in the following comment:

              Great!
              I don't mind bumping the urwid version to the latest stable, but it can be done after this PR is merged.
              I've added format test to CI on master, so just please rebase, apply formatting and I'll merge
_Originally posted by @amanusk in https://github.com/amanusk/s-tui/issues/228#issuecomment-2869532961_

Not sure if there is anywhere else it should be bumped, but couldn't find another reference to the urwid version.