### PR TITLE
resolve regex library warnings

### DIFF
--- a/s_tui/helper_functions.py
+++ b/s_tui/helper_functions.py
@@ -52,7 +52,7 @@ def get_processor_name():
             all_info = cpuinfo.readlines()
             for line in all_info:
                 if b"model name" in line:
-                    return re.sub(b".*model name.*:", b"", line, 1)
+                    return re.sub(b".*model name.*:", b"", line, count=1)
     elif platform.system() == "FreeBSD":
         cmd = ["sysctl", "-n", "hw.model"]
         process = subprocess.Popen(


### PR DESCRIPTION
## PR Summary
This small PR resolves the annoying regex library warnings showing starting Python3.11:
```python
/tmp/s-tui/s_tui/helper_functions.py:55 DeprecationWarning: 'count' is passed as positional argument
```