### PR TITLE
load_config: do not treat ':' as delimiter

### DIFF
--- a/s_tui/s_tui.py
+++ b/s_tui/s_tui.py
@@ -634,7 +634,7 @@ class GraphController:
         # Use user config file if one was saved before
         self.conf = None
         if user_config_file_exists():
-            self.conf = configparser.ConfigParser()
+            self.conf = configparser.ConfigParser(delimiters="=")
             self.conf.read(get_user_config_file())
         else:
             logging.debug("Config file not found")


### PR DESCRIPTION
The default value of delimiters is `('=', ':')` [source] but sensors might have `:` in the name.

Fixes #239.

[source]: https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour