### PR TITLE
display alert colors only for affected graph

### DIFF
--- a/s_tui/sources/source.py
+++ b/s_tui/sources/source.py
@@ -28,6 +28,7 @@ class Source:
         self.edge_hooks = []
         self.measurement_unit = ""
         self.last_measurement = []
+        self.last_thresholds = []
         self.is_available = True
         self.available_sensors = []
         self.name = ""
@@ -104,6 +105,10 @@ class Source:
     def get_reading_list(self):
         """Returns a list of the last measurement"""
         return self.last_measurement
+
+    def get_threshold_list(self):
+        """Returns a list of the last threshold values"""
+        return self.last_thresholds
 
     def add_edge_hook(self, hook):
         """


### PR DESCRIPTION
At the moment, all graphs of a bar plot series change color if the value of one of them is above a global threshold.

This commit
- adds individual threshold values for sensors, analog to measurements.
- populates those individual thresholds with either sensor.high within temp_source or uses the default if not
- then uses those indivudual thresholds to change colors of individual graphs within a bar plot.

This gives users a better understanding of which sensor(s) was/were the reason for the 'alarm'.

It does not use individual colors for only those bars that are above the threshold but always changes the color for all of the bars of one graph. While it would be nicer to have only those individual bars change color, I am afraid implementing this is beyond my current time budet and not as critial as seeing which of the sensors is poses the problem.

I believe this closes the following two:

Closes #121 
Closes #193 