### PR TITLE
Cache fieldnames and header-written in function output_to_csv

### DIFF
--- a/s_tui/helper_functions.py
+++ b/s_tui/helper_functions.py
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 """Helper functions module with common useful functions"""
 
-
 import os
 import logging
 import platform
@@ -88,26 +87,37 @@ def kill_child_processes(parent_proc):
         logging.debug("Could not kill process")
 
 
+_csv_fieldnames = None
+_csv_header_written = False
+
+
 def output_to_csv(sources, csv_writeable_file):
     """Print statistics to csv file"""
-    file_exists = os.path.isfile(csv_writeable_file)
+    global _csv_fieldnames, _csv_header_written
+
+    csv_dict = OrderedDict()
+    csv_dict.update({"Time": time.strftime("%Y-%m-%d_%H:%M:%S")})
+    summaries = [val for key, val in sources.items()]
+    for summarie in summaries:
+        update_dict = dict()
+        for prob, val in summarie.source.get_sensors_summary().items():
+            prob = summarie.source.get_source_name() + ":" + prob
+            update_dict[prob] = val
+        csv_dict.update(update_dict)
+
+    if _csv_fieldnames is None:
+        _csv_fieldnames = list(csv_dict.keys())
 
     with open(csv_writeable_file, "a") as csvfile:
-        csv_dict = OrderedDict()
-        csv_dict.update({"Time": time.strftime("%Y-%m-%d_%H:%M:%S")})
-        summaries = [val for key, val in sources.items()]
-        for summarie in summaries:
-            update_dict = dict()
-            for prob, val in summarie.source.get_sensors_summary().items():
-                prob = summarie.source.get_source_name() + ":" + prob
-                update_dict[prob] = val
-            csv_dict.update(update_dict)
+        writer = csv.DictWriter(csvfile, fieldnames=_csv_fieldnames)
 
-        fieldnames = [key for key, val in csv_dict.items()]
-        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-
-        if not file_exists:
-            writer.writeheader()  # file doesn't exist yet, write a header
+        if not _csv_header_written:
+            if (
+                not os.path.isfile(csv_writeable_file)
+                or os.path.getsize(csv_writeable_file) == 0
+            ):
+                writer.writeheader()
+            _csv_header_written = True
         writer.writerow(csv_dict)
 
 


### PR DESCRIPTION
## Cache CSV fieldnames and header-written state in `output_to_csv`

I noticed that, under the `helper_functions` file, `output_to_csv` is called on every refresh cycle from `animate_graph`. On each call it was:

1. Rebuilding the `fieldnames` list from the `OrderedDict` keys
2. Constructing a new `csv.DictWriter` with those fieldnames
3. Calling `os.path.isfile()` to decide whether to write the CSV header

The changed code in the PR caches the `fieldnames` list and a `header_written` flag as module-level globals in `output_to_csv`, so they are computed once on the first call and reused on every subsequent call.
It avoids rebuilding the fieldnames list and performing an `os.path.isfile` check on every refresh cycle.

The fieldnames are derived from `Source.name` and `Source.available_sensors`, both of which are set once during `__init__` and never mutated at RUNTIME. The set of sources in `self.view.summaries` is also fixed after `main_window()` constructs it. As far as I understand and have tested, this makes the fieldnames safe to cache.

### Changes

- Added `_csv_fieldnames` module-level cache: computed on the first call to `output_to_csv`, reused on all subsequent calls
- Added `_csv_header_written` module-level flag: after the first call determines whether the header needs writing (via `os.path.isfile` / `os.path.getsize`), the flag is set and filesystem checks are skipped on all future calls