### PR TITLE
Fixed error on freq_source when no freq found

### DIFF
--- a/s_tui/sources/freq_source.py
+++ b/s_tui/sources/freq_source.py
@@ -49,6 +49,11 @@ class FreqSource(Source):
         per_cpu_freq = psutil.cpu_freq(True)
         overall_freq = psutil.cpu_freq(False)
 
+        # Set as not available if no cpu freq
+        if len(per_cpu_freq) == 0 and not overall_freq:
+                self.is_available = False
+                return
+
         # +1 for average frequency
         self.last_measurement = [0] * len(per_cpu_freq)
         if overall_freq:


### PR DESCRIPTION
Program previously raised unhandled exception when freq_source had no data This can happen on virtual machines

Added check that array is not null and will set as not available if no data is found



**Example of exception thrown**
```
Traceback (most recent call last):
  File "/usr/bin/s-tui", line 33, in <module>
    sys.exit(load_entry_point('s-tui==1.1.6', 'console_scripts', 's-tui')())
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/s_tui/s_tui.py", line 958, in main
    graph_controller = GraphController(args)
  File "/usr/lib/python3/dist-packages/s_tui/s_tui.py", line 758, in __init__
    possible_sources = self._load_config(args.t_thresh)
  File "/usr/lib/python3/dist-packages/s_tui/s_tui.py", line 688, in _load_config
    FreqSource(),
    ~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/s_tui/sources/freq_source.py", line 54, in __init__
    self.top_freq = psutil.cpu_freq().max
                    ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'max'
```

This happens when host CPU information is not passed to the virtual machine.