### PR TITLE
Handle dynamic Energy Performance Preference in Power Profile

### DIFF
--- a/s_tui/power_profile_menu.py
+++ b/s_tui/power_profile_menu.py
@@ -137,8 +137,10 @@ class PowerProfileMenu:
         can_write_epp: bool,
         available_governors: list[str] | None = None,
         available_epp: list[str] | None = None,
+        update_size_fn: Callable[[int, int], None] | None = None,
     ) -> None:
         self.return_fn = return_fn
+        self.update_size_fn = update_size_fn
         self.powerprofilesctl_exe = powerprofilesctl_exe
         self.can_write_governor = can_write_governor
         self.can_write_epp = can_write_epp
@@ -170,8 +172,10 @@ class PowerProfileMenu:
         self.titles: list[urwid.Widget] = []
         self._build_ui()
 
+        # Store walker reference for live updates
+        self.walker = urwid.SimpleFocusListWalker(self.titles)
         self.main_window = urwid.LineBox(
-            ViListBox(urwid.SimpleFocusListWalker(self.titles)),
+            ViListBox(self.walker),
             title="Power Profile",
         )
 
@@ -230,9 +234,9 @@ class PowerProfileMenu:
 
         apply_button = urwid.Button("Apply", on_press=self.on_apply)
         apply_button._label.align = "center"
-        cancel_button = urwid.Button("Cancel", on_press=self.on_cancel)
-        cancel_button._label.align = "center"
-        self.titles.append(urwid.Columns([apply_button, cancel_button]))
+        close_button = urwid.Button("Close", on_press=self.on_close)
+        close_button._label.align = "center"
+        self.titles.append(urwid.Columns([apply_button, close_button]))
 
     def get_size(self) -> tuple[int, int]:
         return len(self.titles) + 5, self.MAX_TITLE_LEN
@@ -272,7 +276,7 @@ class PowerProfileMenu:
         return None
 
     def on_apply(self, _: object) -> None:
-        """Apply the selected governor and/or EPP."""
+        """Apply the selected governor and/or EPP, then refresh available lists."""
         errors = []
 
         # Apply governor
@@ -297,11 +301,33 @@ class PowerProfileMenu:
                     logging.debug("Failed to set EPP: %s", e)
                     errors.append(str(e))
 
+        # Refresh the UI after gov/epp change
+        self._refresh_ui_lists()
+
         if errors:
             self.status_text.set_text(("high temp txt", "\n".join(errors)))
         else:
-            self.status_text.set_text("")
-            self.return_fn()
+            self.status_text.set_text(("bold text", "Applied successfully."))
+
+    def _refresh_ui_lists(self) -> None:
+        """Re-read available sysfs values and dynamically rebuild the UI."""
+        self.available_governors = read_available(SYSFS_AVAIL_GOVERNORS)
+        self.available_epp = read_available(SYSFS_AVAIL_EPP)
+
+        self.governor_controllable = (
+            self.can_write_governor and len(self.available_governors) > 1
+        )
+        self.epp_controllable = (
+            self.can_write_epp or self.powerprofilesctl_exe is not None
+        ) and len(self.available_epp) > 0
+
+        self.titles.clear()
+        self._build_ui()
+        self.walker[:] = self.titles
+
+        if self.update_size_fn:
+            new_height, new_width = self.get_size()
+            self.update_size_fn(new_height, new_width)
 
     def _apply_epp(self, epp: str) -> None:
         """Apply EPP value using the best available method."""
@@ -324,7 +350,6 @@ class PowerProfileMenu:
             f"and no sysfs write permission"
         )
 
-    def on_cancel(self, _: object) -> None:
-        """Reset radio buttons to current state and close."""
-        self.refresh_state()
+    def on_close(self, _: object) -> None:
+        """Close the window unconditionally."""
         self.return_fn()

--- a/s_tui/power_profile_menu.py
+++ b/s_tui/power_profile_menu.py
@@ -174,10 +174,7 @@ class PowerProfileMenu:
 
         # Store walker reference for live updates
         self.walker = urwid.SimpleFocusListWalker(self.titles)
-        self.main_window = urwid.LineBox(
-            ViListBox(self.walker),
-            title="Power Profile",
-        )
+        self.main_window = urwid.LineBox(ViListBox(self.walker))
 
     def _build_ui(self) -> None:
         title = urwid.Text(("bold text", "  Power Profile  \n"), "center")

--- a/s_tui/s_tui.py
+++ b/s_tui/s_tui.py
@@ -455,6 +455,11 @@ class GraphView(urwid.WidgetPlaceholder):
         can_write_governor = os.access(SYSFS_GOVERNOR, os.W_OK)
         can_write_epp = os.access(SYSFS_EPP, os.W_OK)
 
+        def _update_power_profile_menu_size(new_height: int, new_width: int) -> None:
+            if isinstance(self.original_widget, urwid.Overlay):
+                self.original_widget = self.original_widget.bottom_w
+                self._open_menu_overlay(menu)
+
         menu = PowerProfileMenu(
             return_fn=self.on_menu_close,
             powerprofilesctl_exe=self.controller.powerprofilesctl_exe,
@@ -462,6 +467,7 @@ class GraphView(urwid.WidgetPlaceholder):
             can_write_epp=can_write_epp,
             available_governors=available_governors,
             available_epp=available_epp,
+            update_size_fn=_update_power_profile_menu_size,
         )
         if not menu.is_controllable():
             logging.info("Power profile menu: nothing controllable, hiding")

--- a/tests/test_power_profile_menu.py
+++ b/tests/test_power_profile_menu.py
@@ -258,7 +258,8 @@ class TestApplyEpp:
             "/sys/devices/system/cpu/cpu*/cpufreq/energy_performance_preference",
             "performance",
         )
-        assert m.return_fn.call_count == 1  # type: ignore[union-attr]
+        assert m.return_fn.call_count == 0  # type: ignore[union-attr]
+        assert m.status_text.text == "Applied successfully."
 
     def test_apply_epp_busy_no_sysfs_shows_short_error(self, menu_epp_only):
         """When powerprofilesctl returns 'busy' and no sysfs, show a short error."""
@@ -277,20 +278,14 @@ class TestApplyEpp:
 
 
 # =====================================================================
-# Cancel
+# Close
 # =====================================================================
 
 
-class TestCancel:
-    def test_cancel_calls_return_fn(self, menu_full):
-        with patch.object(menu_full, "refresh_state"):
-            menu_full.on_cancel(None)
+class TestClose:
+    def test_close_calls_return_fn(self, menu_full):
+        menu_full.on_close(None)
         menu_full.return_fn.assert_called_once()
-
-    def test_cancel_refreshes_state(self, menu_full):
-        with patch.object(menu_full, "refresh_state") as mock_refresh:
-            menu_full.on_cancel(None)
-        mock_refresh.assert_called_once()
 
 
 # =====================================================================


### PR DESCRIPTION
The amd-pstate driver changes the list of available Energy Performance Preference (EPP) based on the scaling governor. The list is different if you pick performance or powersave.

The current implementation doesn't handles such case correctly. To see the updated list of EPP user must restart the whole program. Change that by introducing a live updated of the Overlay (content and size) after
the scaling governor has been applied.

With that behavior change, the "Cancel" button doesn't make much sense now, so change it to "Close".