### PR TITLE
Narrow EPP choices reactively when a write is rejected (Intel fix)

### DIFF
--- a/s_tui/power_profile_menu.py
+++ b/s_tui/power_profile_menu.py
@@ -288,6 +288,7 @@ class PowerProfileMenu:
                     errors.append(str(e))
 
         # Apply EPP
+        epp_write_failed = False
         if self.epp_controllable:
             epp = self._get_selected_epp()
             if epp:
@@ -297,19 +298,31 @@ class PowerProfileMenu:
                 except OSError as e:
                     logging.debug("Failed to set EPP: %s", e)
                     errors.append(str(e))
+                    epp_write_failed = True
 
         # Refresh the UI after gov/epp change
-        self._refresh_ui_lists()
+        self._refresh_ui_lists(epp_write_failed)
 
         if errors:
             self.status_text.set_text(("high temp txt", "\n".join(errors)))
         else:
             self.status_text.set_text(("bold text", "Applied successfully."))
 
-    def _refresh_ui_lists(self) -> None:
-        """Re-read available sysfs values and dynamically rebuild the UI."""
+    def _refresh_ui_lists(self, epp_write_failed: bool = False) -> None:
+        """Re-read available sysfs values and dynamically rebuild the UI.
+
+        Some drivers (e.g. intel_pstate) don't shrink
+        energy_performance_available_preferences to reflect the active
+        governor the way amd-pstate does, so a rejected EPP write is the only
+        signal we get. When the just-attempted write failed, trust the
+        kernel's real, current EPP value over the (stale) advertised list.
+        """
         self.available_governors = read_available(SYSFS_AVAIL_GOVERNORS)
         self.available_epp = read_available(SYSFS_AVAIL_EPP)
+        if epp_write_failed:
+            current_epp = _read_current(SYSFS_EPP)
+            if current_epp:
+                self.available_epp = [current_epp]
 
         self.governor_controllable = (
             self.can_write_governor and len(self.available_governors) > 1

--- a/tests/test_power_profile_menu.py
+++ b/tests/test_power_profile_menu.py
@@ -115,6 +115,83 @@ class TestConstruction:
         assert m.is_controllable()
 
 
+class TestEppReactiveNarrowing:
+    """Some drivers (e.g. intel_pstate) don't shrink
+    energy_performance_available_preferences to reflect the active governor
+    the way amd-pstate does. Rather than guessing driver-specific rules, a
+    rejected EPP write is treated as the ground truth: narrow the list to
+    the real current EPP value, and trust the advertised list again as soon
+    as a write succeeds."""
+
+    def test_construction_never_restricts_epp_list(self):
+        """No write has been attempted yet, so show whatever sysfs advertises."""
+        with patch(
+            "s_tui.power_profile_menu._read_current", return_value="performance"
+        ):
+            m = PowerProfileMenu(
+                return_fn=MagicMock(),
+                powerprofilesctl_exe=None,
+                can_write_governor=True,
+                can_write_epp=True,
+                available_governors=GOVERNORS,
+                available_epp=EPP_VALUES,
+            )
+        assert m.available_epp == EPP_VALUES
+
+    def test_failed_epp_write_narrows_to_current_value(self):
+        with patch("s_tui.power_profile_menu._read_current", return_value="powersave"):
+            m = PowerProfileMenu(
+                return_fn=MagicMock(),
+                powerprofilesctl_exe=None,
+                can_write_governor=False,
+                can_write_epp=True,
+                available_governors=["powersave"],
+                available_epp=EPP_VALUES,
+            )
+
+        for rb in m.epp_group:
+            rb.set_state(rb.label == "power", do_callback=False)
+
+        with (
+            patch(
+                "s_tui.power_profile_menu._write_all_cores",
+                side_effect=OSError("Device or resource busy"),
+            ),
+            patch("s_tui.power_profile_menu.read_available", return_value=EPP_VALUES),
+            patch("s_tui.power_profile_menu._read_current", return_value="performance"),
+        ):
+            m.on_apply(None)
+
+        assert m.available_epp == ["performance"]
+        assert len(m.epp_buttons) == 1
+        status = m.status_text.get_text()[0]
+        assert "busy" in status.lower()
+
+    def test_successful_epp_write_keeps_full_list(self):
+        with patch("s_tui.power_profile_menu._read_current", return_value="powersave"):
+            m = PowerProfileMenu(
+                return_fn=MagicMock(),
+                powerprofilesctl_exe=None,
+                can_write_governor=False,
+                can_write_epp=True,
+                available_governors=["powersave"],
+                available_epp=EPP_VALUES,
+            )
+
+        for rb in m.epp_group:
+            rb.set_state(rb.label == "power", do_callback=False)
+
+        with (
+            patch("s_tui.power_profile_menu._write_all_cores"),
+            patch("s_tui.power_profile_menu.read_available", return_value=EPP_VALUES),
+            patch("s_tui.power_profile_menu._read_current", return_value="powersave"),
+        ):
+            m.on_apply(None)
+
+        assert m.available_epp == EPP_VALUES
+        assert len(m.epp_buttons) == len(EPP_VALUES)
+
+
 # =====================================================================
 # get_size
 # =====================================================================


### PR DESCRIPTION
## Summary

- PR #287 refreshes the Power Profile menu's EPP list after Apply, relying on the kernel updating `energy_performance_available_preferences` to reflect the active governor. `amd-pstate` does this; `intel_pstate` doesn't — that file always lists every EPP value regardless of governor.
- As a result, on Intel systems with the `performance` governor active, the menu kept offering EPP choices (`balance_performance`, `power`, etc.) that the hardware silently rejects on Apply with "Device or resource busy".
- Since Intel gives no dynamic listing to read from, this uses the write's own success/failure as the signal instead: when an EPP write is rejected, trust the real current EPP value (read back from sysfs) over the stale advertised list and narrow to just that value. A successful write keeps trusting the full list as before.
- No driver-name checks or hardcoded EPP values — behavior on `amd-pstate` systems is unchanged since the list there is already correctly narrowed by the kernel and writes succeed.

## Test plan

- [x] `python -m pytest tests/test_power_profile_menu.py -q` — 31 passed
- [x] `python -m pytest -q` — 403 passed, 1 skipped (full suite)
- [x] Verified live on an Intel `intel_pstate` machine with `performance` governor active: `energy_performance_available_preferences` lists all 5 EPP values regardless of governor, confirming the bug's root cause
- [ ] Manual verification on an AMD `amd-pstate` system that the existing dynamic narrowing still works (not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)