### PR TITLE
Do not show a strategy if it is not available

### DIFF
--- a/s_tui/builtin_stress_menu.py
+++ b/s_tui/builtin_stress_menu.py
@@ -30,6 +30,7 @@ import urwid
 from s_tui.builtin_stresser import (
     STRATEGIES,
     STRATEGY_LABELS,
+    STRATEGY_REQUIREMENTS,
     get_default_strategy,
     strategy_available,
 )
@@ -53,14 +54,18 @@ class BuiltinStressMenu:
 
         self.num_workers_ctrl = urwid.Edit("CPU worker count: ", self.num_workers)
 
-        # Strategy radio buttons
+        # Unavailable strategies render as plain text so they can't be selected.
         self._strategy_group: list[urwid.RadioButton] = []
         self._strategy_buttons: dict[str, urwid.RadioButton] = {}
         strategy_widgets: list[urwid.Widget] = []
         for key in STRATEGIES:
             label = STRATEGY_LABELS[key]
             if not strategy_available(key):
-                label += " (requires numpy)"
+                hint = STRATEGY_REQUIREMENTS.get(key, "unavailable")
+                strategy_widgets.append(
+                    urwid.Text([f"  {label} ", ("high temp txt", f"({hint})")])
+                )
+                continue
             rb = urwid.RadioButton(
                 self._strategy_group,
                 label,
@@ -134,7 +139,9 @@ class BuiltinStressMenu:
             self.num_workers = raw
         else:
             self.num_workers = str(psutil.cpu_count() or 1)
-        self.strategy = self._pending_strategy
+        # Only commit a selectable strategy, else the UI desyncs from what runs.
+        if self._pending_strategy in self._strategy_buttons:
+            self.strategy = self._pending_strategy
         self._restore_ui()
         self.return_fn()
 

--- a/s_tui/builtin_stresser.py
+++ b/s_tui/builtin_stresser.py
@@ -51,8 +51,13 @@ STRATEGY_HASHLIB = "hashlib"
 STRATEGIES = [STRATEGY_NUMPY, STRATEGY_HASHLIB]
 
 STRATEGY_LABELS = {
-    STRATEGY_NUMPY: "numpy matmul burn",
+    STRATEGY_NUMPY: "matmul burn",
     STRATEGY_HASHLIB: "hashlib SHA-256",
+}
+
+# Hint shown in the menu when a strategy is unavailable.
+STRATEGY_REQUIREMENTS = {
+    STRATEGY_NUMPY: "requires numpy",
 }
 
 

--- a/tests/test_builtin_stress_menu.py
+++ b/tests/test_builtin_stress_menu.py
@@ -2,8 +2,13 @@
 
 import psutil
 
+import s_tui.builtin_stresser as builtin_stresser
 from s_tui.builtin_stress_menu import BuiltinStressMenu
-from s_tui.builtin_stresser import STRATEGY_HASHLIB, get_default_strategy
+from s_tui.builtin_stresser import (
+    STRATEGY_HASHLIB,
+    STRATEGY_NUMPY,
+    get_default_strategy,
+)
 
 
 class TestBuiltinStressMenu:
@@ -53,4 +58,30 @@ class TestBuiltinStressMenu:
         menu = BuiltinStressMenu(return_fn=lambda: None)
         menu._pending_strategy = STRATEGY_HASHLIB
         menu.on_save(None)
+        assert menu.get_strategy() == STRATEGY_HASHLIB
+
+    def test_numpy_not_selectable_when_unavailable(self, monkeypatch):
+        """When numpy is missing, its strategy has no selectable radio button.
+
+        Guards against the UI showing "numpy" selected while start() silently
+        falls back to hashlib.
+        """
+        monkeypatch.setattr(builtin_stresser, "_HAS_NUMPY", False)
+        menu = BuiltinStressMenu(return_fn=lambda: None)
+
+        # numpy must not be among the selectable radio buttons
+        assert STRATEGY_NUMPY not in menu._strategy_buttons
+        assert STRATEGY_HASHLIB in menu._strategy_buttons
+
+        # Default and committed strategy fall back to an available kernel
+        assert menu.get_strategy() == STRATEGY_HASHLIB
+
+        # Even a forced pending numpy selection (not reachable via the UI) is
+        # ignored on save rather than desyncing the committed strategy
+        menu._pending_strategy = STRATEGY_NUMPY
+        menu.on_save(None)
+        assert menu.get_strategy() == STRATEGY_HASHLIB
+
+        # on_default re-derives an available strategy
+        menu.on_default(None)
         assert menu.get_strategy() == STRATEGY_HASHLIB


### PR DESCRIPTION
If a stress kernel does not have all requirements for it to run, show it as plain text, and show the requirement for it to become available