### PR TITLE
Save stress menu options between sessions

### DIFF
--- a/s_tui/builtin_stress_menu.py
+++ b/s_tui/builtin_stress_menu.py
@@ -39,7 +39,12 @@ from s_tui.builtin_stresser import (
 class BuiltinStressMenu:
     MAX_TITLE_LEN = 50
 
-    def __init__(self, return_fn: Callable[[], None]) -> None:
+    def __init__(
+        self,
+        return_fn: Callable[[], None],
+        initial_strategy: str | None = None,
+        initial_workers: str | None = None,
+    ) -> None:
         self.return_fn = return_fn
 
         self.num_workers = "1"
@@ -49,8 +54,19 @@ class BuiltinStressMenu:
         except OSError as err:
             logging.debug(err)
 
+        # Restore a saved worker count when it is a valid positive integer.
+        if (
+            initial_workers is not None
+            and re.match(r"\A[0-9]+\Z", initial_workers)
+            and int(initial_workers) > 0
+        ):
+            self.num_workers = initial_workers
+
+        # Honour a saved strategy only if it can actually run here, else fall
+        # back so _restore_ui never indexes a missing radio button.
         self.strategy = get_default_strategy()
-        self._pending_strategy = self.strategy
+        if initial_strategy in STRATEGIES and strategy_available(initial_strategy):
+            self.strategy = initial_strategy
 
         self.num_workers_ctrl = urwid.Edit("CPU worker count: ", self.num_workers)
 
@@ -70,8 +86,6 @@ class BuiltinStressMenu:
                 self._strategy_group,
                 label,
                 state=(key == self.strategy),
-                on_state_change=self._on_strategy_change,
-                user_data=key,
             )
             self._strategy_buttons[key] = rb
             strategy_widgets.append(rb)
@@ -79,7 +93,9 @@ class BuiltinStressMenu:
         default_button = urwid.Button("Default", on_press=self.on_default)
         default_button._label.align = "center"
 
-        save_button = urwid.Button("Save", on_press=self.on_save)
+        # "Apply" acts within the session; the main "Save settings" persists
+        # the choice across restarts.
+        save_button = urwid.Button("Apply", on_press=self.on_save)
         save_button._label.align = "center"
 
         cancel_button = urwid.Button("Cancel", on_press=self.on_cancel)
@@ -101,11 +117,12 @@ class BuiltinStressMenu:
 
         self.main_window = urwid.LineBox(urwid.ListBox(self.titles))
 
-    def _on_strategy_change(
-        self, button: urwid.RadioButton, state: bool, key: str
-    ) -> None:
-        if state:
-            self._pending_strategy = key
+    def _selected_strategy(self) -> str:
+        """Return the strategy key of the currently checked radio button."""
+        for key, button in self._strategy_buttons.items():
+            if button.state:
+                return key
+        return self.strategy
 
     def get_size(self) -> tuple[int, int]:
         return len(self.titles) + 5, self.MAX_TITLE_LEN
@@ -125,7 +142,6 @@ class BuiltinStressMenu:
         """Reset UI controls to match committed state."""
         self.num_workers_ctrl.set_edit_text(self.num_workers)
         self._strategy_buttons[self.strategy].set_state(True)
-        self._pending_strategy = self.strategy
 
     def on_default(self, _) -> None:
         self.num_workers = str(psutil.cpu_count() or 1)
@@ -139,9 +155,9 @@ class BuiltinStressMenu:
             self.num_workers = raw
         else:
             self.num_workers = str(psutil.cpu_count() or 1)
-        # Only commit a selectable strategy, else the UI desyncs from what runs.
-        if self._pending_strategy in self._strategy_buttons:
-            self.strategy = self._pending_strategy
+        # Read the checked radio directly; urwid's 'change' callback arg order
+        # varies across builds and can't be relied on (issue #289).
+        self.strategy = self._selected_strategy()
         self._restore_ui()
         self.return_fn()
 

--- a/s_tui/s_tui.py
+++ b/s_tui/s_tui.py
@@ -261,7 +261,11 @@ class GraphView(urwid.WidgetPlaceholder):
 
         # construct the various menus during init phase
         self.stress_menu = StressMenu(self.on_menu_close, self.controller.stress_exe)
-        self.builtin_stress_menu = BuiltinStressMenu(self.on_menu_close)
+        self.builtin_stress_menu = BuiltinStressMenu(
+            self.on_menu_close,
+            self.controller.stress_strategy,
+            self.controller.stress_workers,
+        )
         self.help_menu = HelpMenu(self.on_menu_close)
         self.about_menu = AboutMenu(self.on_menu_close)
         self.graphs_menu = SensorsMenu(
@@ -784,6 +788,28 @@ class GraphController:
                 ):
                     logging.debug("No user config for temp threshold")
 
+            try:
+                self.stress_strategy = self.conf.get("GraphControl", "strategy")
+                logging.debug(
+                    "Built-in stress strategy set to %s", self.stress_strategy
+                )
+            except (
+                ValueError,
+                configparser.NoOptionError,
+                configparser.NoSectionError,
+            ):
+                logging.debug("No user config for stress strategy")
+
+            try:
+                self.stress_workers = self.conf.get("GraphControl", "workers")
+                logging.debug("Built-in stress workers set to %s", self.stress_workers)
+            except (
+                ValueError,
+                configparser.NoOptionError,
+                configparser.NoSectionError,
+            ):
+                logging.debug("No user config for stress workers")
+
         if t_thresh is not None:
             self.temp_thresh = t_thresh
 
@@ -852,6 +878,10 @@ class GraphController:
         self.graphs_default_conf = defaultdict(dict)
 
         self.temp_thresh = None
+
+        # Built-in stresser settings, restored from config if present
+        self.stress_strategy = None
+        self.stress_workers = None
 
         possible_sources = self._load_config(args.t_thresh)
 
@@ -979,6 +1009,17 @@ class GraphController:
             # Save the configured t_thresh
             if self.temp_thresh:
                 conf.set("GraphControl", "TTHRESH", str(self.temp_thresh))
+            # Save the selected built-in stresser strategy and worker count
+            conf.set(
+                "GraphControl",
+                "strategy",
+                self.view.builtin_stress_menu.get_strategy(),
+            )
+            conf.set(
+                "GraphControl",
+                "workers",
+                str(self.view.builtin_stress_menu.get_num_workers()),
+            )
 
             _save_displayed_setting(conf, "Graphs")
             _save_displayed_setting(conf, "Summaries")

--- a/tests/test_builtin_stress_menu.py
+++ b/tests/test_builtin_stress_menu.py
@@ -44,21 +44,60 @@ class TestBuiltinStressMenu:
         menu = BuiltinStressMenu(return_fn=lambda: None)
         assert menu.get_strategy() == get_default_strategy()
 
-    def test_cancel_restores_strategy(self):
-        """Cancel reverts pending strategy change."""
+    def test_cancel_restores_strategy(self, monkeypatch):
+        """Cancel reverts an unsaved radio selection."""
+        monkeypatch.setattr(builtin_stresser, "_HAS_NUMPY", True)
         menu = BuiltinStressMenu(return_fn=lambda: None)
         original = menu.get_strategy()
-        # Simulate radio button change (would normally be triggered by UI)
-        menu._pending_strategy = STRATEGY_HASHLIB
+        other = STRATEGY_HASHLIB if original != STRATEGY_HASHLIB else STRATEGY_NUMPY
+        # Select the other radio the way a real click does, then cancel.
+        menu._strategy_buttons[other].set_state(True)
         menu.on_cancel(None)
         assert menu.get_strategy() == original
+        assert menu._strategy_buttons[original].state is True
 
-    def test_save_commits_strategy(self):
-        """Save commits the pending strategy change."""
+    def test_save_commits_strategy(self, monkeypatch):
+        """Save persists the strategy selected in the radio group (issue #289)."""
+        monkeypatch.setattr(builtin_stresser, "_HAS_NUMPY", True)
         menu = BuiltinStressMenu(return_fn=lambda: None)
-        menu._pending_strategy = STRATEGY_HASHLIB
+        # Select hashlib via the actual widget state, not an internal shortcut.
+        menu._strategy_buttons[STRATEGY_HASHLIB].set_state(True)
         menu.on_save(None)
         assert menu.get_strategy() == STRATEGY_HASHLIB
+
+    def test_initial_strategy_restored_from_config(self, monkeypatch):
+        """A saved strategy is honoured on construction (issue #289)."""
+        monkeypatch.setattr(builtin_stresser, "_HAS_NUMPY", True)
+        menu = BuiltinStressMenu(
+            return_fn=lambda: None, initial_strategy=STRATEGY_HASHLIB
+        )
+        assert menu.get_strategy() == STRATEGY_HASHLIB
+        assert menu._strategy_buttons[STRATEGY_HASHLIB].state is True
+
+    def test_initial_strategy_falls_back_when_unavailable(self, monkeypatch):
+        """A saved but unrunnable strategy falls back to an available one."""
+        monkeypatch.setattr(builtin_stresser, "_HAS_NUMPY", False)
+        menu = BuiltinStressMenu(
+            return_fn=lambda: None, initial_strategy=STRATEGY_NUMPY
+        )
+        assert menu.get_strategy() == STRATEGY_HASHLIB
+
+    def test_initial_strategy_ignores_garbage(self):
+        """An unknown saved value falls back to the default strategy."""
+        menu = BuiltinStressMenu(return_fn=lambda: None, initial_strategy="bogus")
+        assert menu.get_strategy() == get_default_strategy()
+
+    def test_initial_workers_restored_from_config(self):
+        """A saved worker count is honoured on construction (issue #289)."""
+        menu = BuiltinStressMenu(return_fn=lambda: None, initial_workers="3")
+        assert menu.get_num_workers() == 3
+
+    def test_initial_workers_ignores_invalid(self, monkeypatch):
+        """An invalid saved worker count falls back to the CPU count."""
+        monkeypatch.setattr(psutil, "cpu_count", lambda: 8)
+        for bad in ("0", "-2", "abc", ""):
+            menu = BuiltinStressMenu(return_fn=lambda: None, initial_workers=bad)
+            assert menu.get_num_workers() == 8
 
     def test_numpy_not_selectable_when_unavailable(self, monkeypatch):
         """When numpy is missing, its strategy has no selectable radio button.
@@ -76,9 +115,8 @@ class TestBuiltinStressMenu:
         # Default and committed strategy fall back to an available kernel
         assert menu.get_strategy() == STRATEGY_HASHLIB
 
-        # Even a forced pending numpy selection (not reachable via the UI) is
-        # ignored on save rather than desyncing the committed strategy
-        menu._pending_strategy = STRATEGY_NUMPY
+        # numpy has no radio button, so it cannot be selected or committed;
+        # saving keeps the available kernel rather than desyncing.
         menu.on_save(None)
         assert menu.get_strategy() == STRATEGY_HASHLIB
 

--- a/tests/test_config_delimiter.py
+++ b/tests/test_config_delimiter.py
@@ -86,6 +86,9 @@ class TestConfigDelimiter:
             mock_view.summary_menu.active_sensors = {
                 "CPU Util": [True, True],
             }
+            mock_view.builtin_stress_menu = MagicMock()
+            mock_view.builtin_stress_menu.get_strategy.return_value = "hashlib"
+            mock_view.builtin_stress_menu.get_num_workers.return_value = 4
             mock_view_class.return_value = mock_view
 
             controller = GraphController(MagicMock())
@@ -120,6 +123,41 @@ class TestConfigDelimiter:
             assert any(
                 "=" in line and ":" not in line.split("=")[0] for line in lines
             ), "Config should use '=' as delimiter, not ':' (PR #254 fix)"
+
+            # Built-in stresser strategy and worker count are persisted (#289)
+            assert "strategy = hashlib" in config_content
+            assert "workers = 4" in config_content
+
+    def test_load_config_reads_stress_settings(self, tmp_path, mocker):
+        """_load_config restores the built-in stresser strategy and workers (#289)."""
+        from collections import defaultdict
+
+        from s_tui.s_tui import GraphController
+
+        cfg = tmp_path / "s-tui.conf"
+        cfg.write_text("[GraphControl]\nstrategy = hashlib\nworkers = 3\n")
+
+        mocker.patch("s_tui.s_tui.user_config_dir_exists", return_value=True)
+        mocker.patch("s_tui.s_tui.get_user_config_dir", return_value=str(tmp_path))
+        mocker.patch("s_tui.s_tui.user_config_file_exists", return_value=True)
+        mocker.patch("s_tui.s_tui.get_user_config_file", return_value=str(cfg))
+
+        # Exercise the real _load_config without running full __init__.
+        ctrl = GraphController.__new__(GraphController)
+        ctrl.script_hooks_enabled = True
+        ctrl.script_loader = None
+        ctrl.refresh_rate = "2.0"
+        ctrl.smooth_graph_mode = False
+        ctrl.temp_thresh = None
+        ctrl.stress_strategy = None
+        ctrl.stress_workers = None
+        ctrl.graphs_default_conf = defaultdict(dict)
+        ctrl.summary_default_conf = defaultdict(dict)
+
+        ctrl._load_config(None)
+
+        assert ctrl.stress_strategy == "hashlib"
+        assert ctrl.stress_workers == "3"
 
     def test_configparser_delimiter_consistency(self):
         """Test that ConfigParser with delimiters="=" preserves colons in values.


### PR DESCRIPTION
Apply applies the settings within the session. Save settings saves the settings between sessions, and stores the strategy and num of workers in the default config.
Also uses the data reported by the menu for the strategy application so nothing falls between the cracks