### PR TITLE
Fall back to /proc/device-tree/model for processor name

### DIFF
--- a/s_tui/helper_functions.py
+++ b/s_tui/helper_functions.py
@@ -55,6 +55,14 @@ def get_processor_name() -> str:
             for line in cpuinfo:
                 if "model name" in line:
                     return re.sub(r".*model name.*:", "", line, count=1)
+        # Many ARM SBCs (Raspberry Pi, Orange Pi, Le Potato, ...) have no
+        # "model name" in /proc/cpuinfo, but do expose a useful board name
+        # in the device tree.
+        with contextlib.suppress(OSError):
+            with open("/proc/device-tree/model") as model:
+                name = model.read().rstrip("\x00").strip()
+            if name:
+                return name
     elif platform.system() == "FreeBSD":
         return subprocess.check_output(["sysctl", "-n", "hw.model"], text=True).strip()
     elif platform.system() == "Darwin":

--- a/s_tui/helper_functions.py
+++ b/s_tui/helper_functions.py
@@ -58,11 +58,10 @@ def get_processor_name() -> str:
         # Many ARM SBCs (Raspberry Pi, Orange Pi, Le Potato, ...) have no
         # "model name" in /proc/cpuinfo, but do expose a useful board name
         # in the device tree.
-        with contextlib.suppress(OSError):
-            with open("/proc/device-tree/model") as model:
-                name = model.read().rstrip("\x00").strip()
-            if name:
-                return name
+        model = cat("/proc/device-tree/model", fallback=b"", binary=True)
+        name = model.split(b"\x00", 1)[0].decode(errors="replace").strip()
+        if name:
+            return name
     elif platform.system() == "FreeBSD":
         return subprocess.check_output(["sysctl", "-n", "hw.model"], text=True).strip()
     elif platform.system() == "Darwin":

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -164,7 +164,8 @@ class TestGetProcessorName:
             if file == "/proc/cpuinfo":
                 return io.StringIO("processor\t: 0\nFeatures\t: fp asimd\n")
             if file == "/proc/device-tree/model":
-                return io.StringIO("Libre Computer AML-S905X-CC\x00")
+                # cat() opens this in binary mode
+                return io.BytesIO(b"Libre Computer AML-S905X-CC\x00")
             return real_open(file, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "open", fake_open)

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -152,6 +152,27 @@ class TestGetProcessorName:
         result = get_processor_name()
         assert result is not None
 
+    def test_falls_back_to_device_tree_model(self, monkeypatch):
+        """On boards without 'model name' in /proc/cpuinfo, use the device tree."""
+        import builtins
+        import io
+        import platform
+
+        real_open = builtins.open
+
+        def fake_open(file, *args, **kwargs):
+            if file == "/proc/cpuinfo":
+                return io.StringIO("processor\t: 0\nFeatures\t: fp asimd\n")
+            if file == "/proc/device-tree/model":
+                return io.StringIO("Libre Computer AML-S905X-CC\x00")
+            return real_open(file, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(platform, "processor", lambda: "")
+
+        assert get_processor_name() == "Libre Computer AML-S905X-CC"
+
 
 # ---------------------------------------------------------------------------
 # Config directory helpers


### PR DESCRIPTION
Fixes #210

On ARM SBCs like the Orange Pi 3B and Libre Le Potato, `/proc/cpuinfo` has no `model name` line, so `get_processor_name()` fell through to `platform.processor()` — which returns an empty string on Linux — and the summary showed a blank CPU name. These boards do expose a descriptive name in `/proc/device-tree/model`, so that is now used as a fallback (with the trailing NUL stripped).

Added a regression test that fakes both files; it fails without the change and passes with it.
