### PR TITLE
Handle non-IndexError failures in graph and summary updates

### DIFF
--- a/s_tui/s_tui.py
+++ b/s_tui/s_tui.py
@@ -352,6 +352,10 @@ class GraphView(urwid.WidgetPlaceholder):
                 graph.update()
             except IndexError:
                 logging.debug("Graph update failed")
+            except Exception:
+                logging.exception("Graph update failed with unexpected error")
+                if debug_mode:
+                    raise
 
         # update graph summery
         for summary in self.visible_summaries.values():
@@ -359,6 +363,10 @@ class GraphView(urwid.WidgetPlaceholder):
                 summary.update()
             except IndexError:
                 logging.debug("Summary update failed")
+            except Exception:
+                logging.exception("Summary update failed with unexpected error")
+                if debug_mode:
+                    raise
 
         self._update_cpu_policy()
 

--- a/tests/test_view_update_errors.py
+++ b/tests/test_view_update_errors.py
@@ -1,0 +1,63 @@
+"""Tests for issue #258: graph/summary update errors must not crash the app.
+
+`GraphView.update_displayed_information()` guards `source.update()` against any
+recoverable exception, but the graph and summary rendering loops only caught
+`IndexError`.  Any other exception raised while a widget redraws terminated the
+whole application instead of being logged and skipped.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from s_tui.s_tui import GraphView
+
+
+def make_view(graph=None, summary=None, debug=False):
+    """Build the minimal attribute set update_displayed_information() touches."""
+    view = MagicMock()
+    view.controller.sources = []
+    view.controller.args.debug = debug
+    view.controller.args.debug_run = False
+    view.controller.stress_controller.get_current_mode.return_value = "Monitor"
+    view.source_update_errors = {}
+    view.visible_graphs = {"CPU Util": graph} if graph is not None else {}
+    view.visible_summaries = {"CPU Util": summary} if summary is not None else {}
+    return view
+
+
+class TestGraphSummaryUpdateErrors:
+    @pytest.mark.parametrize(
+        "error", [TypeError("bad shape"), ValueError("bad value"), OSError("gone")]
+    )
+    def test_graph_update_error_does_not_propagate(self, error):
+        """A non-IndexError from graph.update() must not reach the event loop."""
+        graph = MagicMock()
+        graph.update.side_effect = error
+        view = make_view(graph=graph)
+
+        GraphView.update_displayed_information(view)
+
+        assert graph.update.called
+
+    @pytest.mark.parametrize(
+        "error", [TypeError("bad shape"), ValueError("bad value"), OSError("gone")]
+    )
+    def test_summary_update_error_does_not_propagate(self, error):
+        """A non-IndexError from summary.update() must not reach the event loop."""
+        summary = MagicMock()
+        summary.update.side_effect = error
+        view = make_view(summary=summary)
+
+        GraphView.update_displayed_information(view)
+
+        assert summary.update.called
+
+    def test_graph_update_error_raises_in_debug_mode(self):
+        """Debug mode still surfaces unexpected widget errors for diagnosis."""
+        graph = MagicMock()
+        graph.update.side_effect = TypeError("bad shape")
+        view = make_view(graph=graph, debug=True)
+
+        with pytest.raises(TypeError):
+            GraphView.update_displayed_information(view)


### PR DESCRIPTION
Closes #258.

`update_displayed_information()` catches any recoverable exception from `source.update()`, but the graph and summary loops only caught `IndexError`, so a `TypeError`/`ValueError`/`OSError` raised while a widget redrew propagated out of the urwid alarm callback and killed the app. Both loops now follow the same policy as the source loop: log and continue in normal runtime, re-raise in debug mode.

New `tests/test_view_update_errors.py` fails 6/7 without the change and passes 7/7 with it.
