### PR TITLE
Disable buffering on MSR reads

### DIFF
--- a/s_tui/sources/msr.py
+++ b/s_tui/sources/msr.py
@@ -7,7 +7,7 @@ from sys import byteorder
 
 def read_msr(cpu: int, register: int) -> int:
     """Read a 64-bit MSR value from /dev/cpu/{cpu}/msr."""
-    with open(f"/dev/cpu/{cpu}/msr", "rb") as f:
+    with open(f"/dev/cpu/{cpu}/msr", "rb", buffering=0) as f:
         f.seek(register)
         data = f.read(8)
         if len(data) != 8:

--- a/tests/test_msr.py
+++ b/tests/test_msr.py
@@ -13,7 +13,7 @@ class TestReadMsr:
         mock_open = mocker.mock_open(read_data=data)
         mocker.patch("builtins.open", mock_open)
         result = read_msr(3, 0x19C)
-        mock_open.assert_called_once_with("/dev/cpu/3/msr", "rb")
+        mock_open.assert_called_once_with("/dev/cpu/3/msr", "rb", buffering=0)
         mock_open().seek.assert_called_once_with(0x19C)
         assert result == value
 


### PR DESCRIPTION
Python files are buffered, meaning that a read() of 8 bytes might actually trigger a read syscall of ~128 kiB. However, in the case of MSR files, this means that the kernel has to read the MSR about 16k times, significantly slowing down each update cycle.

I observed this behavior with Python 3.14.6 on Debian Forky (testing).