### PR TITLE
fix: handle psutil sensor read failures

### DIFF
--- a/s_tui/sources/fan_source.py
+++ b/s_tui/sources/fan_source.py
@@ -37,12 +37,12 @@ class FanSource(Source):
             self.is_available = False
             logging.debug("Fans sensors is not available from psutil")
             return
-        except TypeError:
+        except (OSError, TypeError):
             # psutil bug: sensors_fans() raises TypeError on some hardware
             # when sysfs fan sensor files contain None (e.g. Intel xe GPU fans)
             # See: https://github.com/amanusk/s-tui/issues/255
             self.is_available = False
-            logging.debug("Fans sensors raised TypeError (psutil bug)")
+            logging.debug("Fans sensors failed (psutil error)")
             return
 
         Source.__init__(self)

--- a/s_tui/sources/freq_source.py
+++ b/s_tui/sources/freq_source.py
@@ -71,12 +71,12 @@ class FreqSource(Source):
         # cpu_freq can raise NotImplementedError if cores are offline at startup
         try:
             per_cpu_freq = psutil.cpu_freq(True)
-        except (OSError, NotImplementedError):
+        except (OSError, NotImplementedError, TypeError):
             per_cpu_freq = None
 
         try:
             overall_freq = psutil.cpu_freq(False)
-        except (OSError, NotImplementedError):
+        except (OSError, NotImplementedError, TypeError):
             overall_freq = None
 
         total_cores = self._get_total_core_count()
@@ -203,7 +203,7 @@ class FreqSource(Source):
     def update(self) -> None:
         try:
             per_cpu_freq = psutil.cpu_freq(True)
-        except (OSError, AttributeError, NotImplementedError) as e:
+        except (OSError, AttributeError, NotImplementedError, TypeError) as e:
             logging.debug("cpu_freq() raised %s: %s", type(e).__name__, e)
             for i in range(1, len(self.sensor_available)):
                 self.sensor_available[i] = False

--- a/s_tui/sources/temp_source.py
+++ b/s_tui/sources/temp_source.py
@@ -45,7 +45,7 @@ class TempSource(Source):
                 logging.debug("sensors_temperatures() returned empty/None")
                 return
             self.is_available = True
-        except (AttributeError, OSError):
+        except (AttributeError, OSError, TypeError):
             self.is_available = False
             logging.debug("cpu temperature is not available from psutil")
             return
@@ -73,7 +73,7 @@ class TempSource(Source):
         sensors_dict = None
         try:
             sensors_dict = OrderedDict(sorted(psutil.sensors_temperatures().items()))
-        except OSError:
+        except (OSError, TypeError):
             logging.debug("Unable to create sensors dict")
             self.is_available = False
             return
@@ -116,7 +116,7 @@ class TempSource(Source):
     def update(self) -> None:
         try:
             sensors_data = psutil.sensors_temperatures()
-        except OSError as e:
+        except (OSError, TypeError) as e:
             logging.debug("sensors_temperatures() raised %s, keeping stale data", e)
             return
 
@@ -198,7 +198,10 @@ class TempSource(Source):
             return self._cached_top_temp
 
         top_temp = 10
-        available_temps = psutil.sensors_temperatures().values()
+        try:
+            available_temps = psutil.sensors_temperatures().values()
+        except (OSError, TypeError):
+            return 10
         for temp in available_temps:
             for temp_minor in temp:
                 if (

--- a/tests/test_psutil_failures.py
+++ b/tests/test_psutil_failures.py
@@ -39,6 +39,25 @@ class TestUtilSourceFailures:
 
 
 class TestFreqSourceFailures:
+    def test_cpu_freq_typeerror_on_init(self, mocker):
+        """A psutil TypeError during startup should mark frequency unavailable."""
+        mocker.patch("psutil.cpu_freq", side_effect=TypeError("missing value"))
+        src = FreqSource()
+        assert isinstance(src, FreqSource)
+
+    def test_cpu_freq_typeerror_on_update(self, mocker):
+        """A psutil TypeError during update should not crash the source."""
+        per_cpu = [type("Freq", (), {"current": 2400.0, "min": 800.0, "max": 3600.0})()]
+        overall = per_cpu[0]
+
+        def cpu_freq(percpu=False):
+            return per_cpu if percpu else overall
+
+        mocker.patch("psutil.cpu_freq", side_effect=cpu_freq)
+        src = FreqSource()
+        mocker.patch("psutil.cpu_freq", side_effect=TypeError("missing value"))
+        src.update()
+
     def test_cpu_freq_returns_none(self, mocker):
         """If cpu_freq returns None (no frequency info), handle gracefully."""
         import contextlib
@@ -69,6 +88,42 @@ class TestFreqSourceFailures:
 
 
 class TestTempSourceFailures:
+    def test_sensors_temperatures_typeerror_on_init(self, mocker):
+        """A psutil TypeError during startup should mark temperature unavailable."""
+        mocker.patch(
+            "psutil.sensors_temperatures", side_effect=TypeError("missing value")
+        )
+        src = TempSource()
+        assert src.get_is_available() is False
+
+    def test_sensors_temperatures_typeerror_on_update(self, mocker):
+        """A psutil TypeError during update should preserve stale temperature data."""
+        temps = OrderedDict(
+            [("coretemp", [SensorTemperature("Core 0", 55.0, 80.0, 100.0)])]
+        )
+        mocker.patch("psutil.sensors_temperatures", return_value=temps)
+        src = TempSource()
+        src.update()
+        old_measurement = list(src.last_measurement)
+
+        mocker.patch(
+            "psutil.sensors_temperatures", side_effect=TypeError("missing value")
+        )
+        src.update()
+        assert src.last_measurement == old_measurement
+
+    def test_sensors_temperatures_typeerror_on_get_top(self, mocker):
+        """A psutil TypeError in the top-temperature path should return its fallback."""
+        temps = OrderedDict(
+            [("coretemp", [SensorTemperature("Core 0", 55.0, 80.0, 100.0)])]
+        )
+        mocker.patch("psutil.sensors_temperatures", return_value=temps)
+        src = TempSource()
+        mocker.patch(
+            "psutil.sensors_temperatures", side_effect=TypeError("missing value")
+        )
+        assert src.get_top() == 10
+
     def test_sensors_temperatures_returns_none(self, mocker):
         """sensors_temperatures() returning None should mark unavailable."""
         mocker.patch("psutil.sensors_temperatures", return_value=None)
@@ -129,6 +184,12 @@ class TestTempSourceFailures:
 
 
 class TestFanSourceFailures:
+    def test_sensors_fans_oserror_on_init(self, mocker):
+        """An OSError during the initial availability probe should not crash."""
+        mocker.patch("psutil.sensors_fans", side_effect=OSError("file disappeared"))
+        src = FanSource()
+        assert src.get_is_available() is False
+
     def test_sensors_fans_returns_none(self, mocker):
         """sensors_fans() returning None should mark unavailable."""
         mocker.patch("psutil.sensors_fans", return_value=None)


### PR DESCRIPTION
## Summary

Fixes #298.

Harden temperature and frequency sources against `TypeError` from psutil when a sysfs sensor read returns `None`. The temperature top-value path and fan startup probe now handle the same transient hardware read failures without crashing. CLI frequency updates are covered too.

## Tests

- `pytest -q` — **430 passed, 3 skipped**
- `ruff check s_tui tests` — pass
- `ruff format --check s_tui tests` — pass
- `git diff --check` — pass

Black reports 3 existing formatting differences in unrelated files.
