### PR TITLE
fix: stop rebuilding Fan/Rapl widget tree every cycle (100% CPU after hours)

### DIFF
--- a/s_tui/sturwid/bar_graph_vector.py
+++ b/s_tui/sturwid/bar_graph_vector.py
@@ -56,8 +56,12 @@ class BarGraphVector(LabeledBarGraphVector):
         for _ in range(graph_count):
             self.graph_data.append([0] * self.num_samples)
 
-        # Set max to 1 as default
-        self.graph_max = 1
+        # Init from get_top(); never use `== 1` as an uninitialized sentinel
+        # since Fan/Rapl legitimately return 1.
+        self.graph_max = max(self.source.get_top(), 1)
+        # Force one rebuild after init/reset so the first update()'s fresh
+        # y_label reaches the screen (the init render used a placeholder).
+        self._needs_rebuild = True
 
         self.color_a = regular_colors[0]
         self.color_b = regular_colors[1]
@@ -203,10 +207,6 @@ class BarGraphVector(LabeledBarGraphVector):
                 graph_display_data.append(None)
 
         update_max = False
-        if self.graph_max == 1:
-            self.graph_max = self.source.get_top()
-            update_max = True
-
         local_max = math.ceil(max(local_top_value))
         if local_max > self.graph_max:
             update_max = True
@@ -238,7 +238,7 @@ class BarGraphVector(LabeledBarGraphVector):
         )
 
         # Sync sensor availability from source and rebuild graphs if changed
-        need_rebuild = update_max
+        need_rebuild = update_max or self._needs_rebuild
         source_available = self.source.sensor_available
         if source_available:
             new_available = source_available[: len(self.sensor_available)]
@@ -248,10 +248,13 @@ class BarGraphVector(LabeledBarGraphVector):
 
         if need_rebuild:
             self.set_visible_graphs()
+            self._needs_rebuild = False
 
     def reset(self):
         self.graph_data = []
         # Like in init, we create new instances for each list
         for _ in range(self.graph_count):
             self.graph_data.append([0] * self.num_samples)
-        self.graph_max = 1
+        self.graph_max = max(self.source.get_top(), 1)
+        # Let the next update() repaint with a fresh y_label.
+        self._needs_rebuild = True


### PR DESCRIPTION
## Summary
- `BarGraphVector.update()` used `if self.graph_max == 1:` as an "uninitialized" sentinel to fire the initial `set_visible_graphs()` rebuild. `FanSource` and `RaplPowerSource` legitimately return `1` from `get_top()`, so on those sources the branch reset `graph_max` back to `1` every cycle and re-triggered a full urwid widget-tree rebuild on every refresh.
- Urwid's internal bookkeeping keeps references to discarded widgets alive, so `gc.get_objects()` climbed ~100/iter. Over several hours the accumulated GC + rebuild cost per cycle crosses the refresh interval and CPU steps up to 100% on one core as the loop stops idling.
- Fix: initialize `graph_max` from `source.get_top()` in `__init__` and `reset()`, drop the `== 1` branch from `update()`, and replace it with an explicit `_needs_rebuild` flag consumed by the next `update()`. That covers the same first-cycle repaint the sentinel used to force (needed so `update()`'s freshly-computed `y_label` reaches the screen — init/reset render with a placeholder). `on_reset_button` in `s_tui.py` already calls `update_displayed_information()` immediately after `reset()`, so the repaint is effectively synchronous.

## Measurements (headless render harness)

| Metric | Pre-fix (500 iters) | Post-fix (1500 iters) |
|---|---|---|
| Fan `set_visible_graphs` calls | **500** (every cycle) | **0** (steady state) |
| `gc.get_objects()` | 51,422 → 99,696 (+96/iter) | flat ~46,000 |
| CanvasCache widgets | ~500 (bounded) | ~500 (bounded) |

## Test plan
- [x] `pytest tests/` — 440 passed, 1 skipped
- [x] Headless render harness confirms Fan graph no longer rebuilds every cycle and `gc.get_objects()` stays flat over 1500 iters
- [x] Visual verification on a real terminal: Fan y-axis started at the placeholder scale, rescaled to 2800 RPM when readings arrived, then stayed put — one rebuild, not per-cycle