### PR TITLE
fix: don't misread process affinity as offline cores under taskset (#303)

### DIFF
--- a/s_tui/sources/util_source.py
+++ b/s_tui/sources/util_source.py
@@ -52,11 +52,11 @@ class UtilSource(Source):
         self.last_measurement = [0.0] * len(self.available_sensors)
         self.sensor_available = [True] * len(self.available_sensors)
 
-        # Affinity cache — refreshed in update() when online core count changes
-        self._cached_online_ids = self._get_online_cpu_ids()
+        # Affinity cache — refreshed in update() when online core count changes.
+        # Only consulted when psutil returns fewer per-cpu entries than total_cores
+        # (real offline cores), so process affinity from taskset doesn't hide cores.
+        self._cached_online_ids: list[int] | None = None
         self._cached_online_len = -1  # force refresh on first update()
-
-        self._mark_offline_cores(total_cores, self._cached_online_ids)
 
     def update(self) -> None:
         try:
@@ -67,7 +67,20 @@ class UtilSource(Source):
         if not per_cpu:
             return
 
-        # Only re-query affinity when the online core count changes
+        num_cores = len(self.available_sensors) - 1  # index 0 is "Avg"
+
+        # Fast path: psutil returned one entry per known core → direct mapping.
+        # Covers the taskset case, where cpu_affinity() would misleadingly report
+        # only the process's affinity mask despite all CPUs being online.
+        if len(per_cpu) >= num_cores:
+            for core_id in range(num_cores):
+                self.last_measurement[core_id + 1] = float(per_cpu[core_id])
+                self.sensor_available[core_id + 1] = True
+            self.last_measurement[0] = sum(per_cpu[:num_cores]) / num_cores
+            return
+
+        # Fewer entries than cores → some cores are truly offline (chcpu -d).
+        # Re-query affinity only when the online count changes.
         if len(per_cpu) != self._cached_online_len:
             self._cached_online_ids = self._get_online_cpu_ids()
             self._cached_online_len = len(per_cpu)
@@ -75,7 +88,6 @@ class UtilSource(Source):
         online_ids = self._cached_online_ids
 
         if online_ids is None:
-            # No cpu_affinity (e.g. macOS) — direct index mapping
             avg = sum(per_cpu) / len(per_cpu)
             self.last_measurement = [avg] + [float(v) for v in per_cpu]
             return
@@ -83,7 +95,6 @@ class UtilSource(Source):
         # cpu_percent(percpu=True) drops offline cores and shifts indices,
         # so per_cpu[i] belongs to online_ids[i], not to core i.
         value_by_core = dict(zip(online_ids, per_cpu))
-        num_cores = len(self.available_sensors) - 1  # index 0 is "Avg"
         online_values = []
 
         for core_id in range(num_cores):

--- a/tests/test_runtime_disruption.py
+++ b/tests/test_runtime_disruption.py
@@ -59,6 +59,32 @@ class TestUtilCoreCountChanges:
         summary = src.get_sensors_summary()
         assert summary is not None
 
+    def test_taskset_affinity_does_not_mark_cores_offline(self, mocker):
+        """Regression for issue #303.
+
+        Running under `taskset -c ...` restricts the process's cpu_affinity()
+        to a subset, but psutil.cpu_percent(percpu=True) still returns every
+        online CPU. All cores must remain available.
+        """
+        mocker.patch("psutil.cpu_count", return_value=8)
+        mocker.patch(
+            "psutil.cpu_percent",
+            return_value=[10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0],
+        )
+        mocker.patch(
+            "s_tui.sources.source.Source._get_total_core_count", return_value=8
+        )
+        mocker.patch(
+            "s_tui.sources.source.Source._get_online_cpu_ids",
+            return_value=[3, 4, 5, 6],
+        )
+        src = UtilSource()
+        src.update()
+
+        readings = src.get_reading_list()
+        assert readings[1:] == [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]
+        assert src.sensor_available[1:] == [True] * 8
+
     def test_core_count_shrinks(self, mocker):
         """Simulate a core going offline mid-run.
 


### PR DESCRIPTION
## Summary
- Fixes #303. `UtilSource` was calling `psutil.Process().cpu_affinity()` to figure out which cores were online, but that returns the process's affinity mask — not the set of online CPUs. Running `taskset -c 3-6 s-tui` therefore made every core outside the mask show as N/A. Bisects to the offline-core feature in #262 (1.4.0).
- `update()` now takes a fast path when psutil returns one per-cpu value per known core (i.e. no cores are actually offline): direct index mapping, affinity ignored. Only falls back to the affinity-based remap when psutil returns fewer entries (real `chcpu -d`).
- Adds a regression test in `tests/test_runtime_disruption.py` mirroring the issue's exact command (`taskset -c 3-6` on 8 cores) that fails without the fix.

## Verification
Ran the probe under every scenario on real hardware (8 cores, cpu0 always on, cpu1-7 chcpu-able):

| Case | Setup | Result |
|---|---|---|
| A | baseline | ✅ all 8 cores ON |
| B | `taskset -c 3` | ✅ all 8 ON |
| C | `taskset -c 3-6` (issue #303) | ✅ all 8 ON |
| D | `taskset -c 0,2,4,6` non-consecutive | ✅ all 8 ON |
| E | cpu1 off | ✅ only 1 N/A |
| F | cpu2 + cpu5 off (non-consecutive) | ✅ only 2, 5 N/A |
| G | cpu3,4,5 off (consecutive) | ✅ only 3-5 N/A |
| H | cpu1-7 off (only cpu0 left) | ✅ only 0 ON |
| I | cpu2,5 off + `taskset -c 0-7` | ✅ only 2, 5 N/A |
| J | cpu4 off + `taskset -c 3-6` | ❌ tracked in #304 |

Case J (taskset combined with actually-offline cores) is a rare edge case that was equally broken before 1.4.0 — no regression, just a known limitation of the offline-detection feature. Fixing it needs an online-CPU source that psutil doesn't expose; tracked separately in #304.

## Test plan
- [x] `pytest tests/` — 441 passed, 1 skipped
- [x] `taskset -c 3-6 s-tui` on real hardware — all cores populate (previously N/A)
- [x] `chcpu -d` scenarios E-H — correct cores show N/A, others populate
- [ ] Reporter (@arrowgent from #303) confirms fix on their system

🤖 Generated with [Claude Code](https://claude.com/claude-code)