### PR TITLE
Honor explicit refresh-rate options over saved settings

### DIFF
--- a/s_tui/s_tui.py
+++ b/s_tui/s_tui.py
@@ -878,7 +878,7 @@ class GraphController:
         self.script_hooks_enabled = True
         self.script_loader = None
 
-        self.refresh_rate = args.refresh_rate
+        self.refresh_rate = "2.0"
 
         self.smooth_graph_mode = False
 
@@ -892,6 +892,8 @@ class GraphController:
         self.stress_workers = None
 
         possible_sources = self._load_config(args.t_thresh)
+        if args.refresh_rate is not None:
+            self.refresh_rate = args.refresh_rate
 
         # Needed for use in view
         self.args = args
@@ -1176,8 +1178,8 @@ def get_args():
         "-r",
         "--refresh-rate",
         dest="refresh_rate",
-        default="2.0",
-        help="Refresh rate in seconds. Default: 2.0",
+        default=None,
+        help="Refresh rate in seconds. Overrides saved settings. Default: 2.0",
     )
     args = parser.parse_args()
     return args

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,9 @@
 import sys
 from unittest.mock import patch
 
-from s_tui.s_tui import get_args
+import pytest
+
+from s_tui.s_tui import GraphController, get_args
 
 
 class TestGetArgs:
@@ -23,7 +25,7 @@ class TestGetArgs:
         assert args.no_mouse is False
         assert args.debug_run is False
         assert args.t_thresh is None
-        assert args.refresh_rate == "2.0"
+        assert args.refresh_rate is None
 
     def test_debug_flag(self):
         args = self._parse(["-d"])
@@ -80,3 +82,56 @@ class TestGetArgs:
         assert args.no_mouse is True
         assert args.t_thresh == "75"
         assert args.refresh_rate == "0.5"
+
+
+class TestRefreshRatePrecedence:
+    @pytest.mark.parametrize(
+        "saved_rate, argv, expected",
+        [
+            (None, [], "2.0"),
+            ("5", [], "5.0"),
+            ("5", ["--refresh-rate", "1"], "1"),
+            ("5", ["-r", "2.0"], "2.0"),
+            (None, ["-r", "0.5"], "0.5"),
+            ("invalid", [], "2.0"),
+            ("invalid", ["-r", "1"], "1"),
+        ],
+    )
+    def test_refresh_rate_precedence(
+        self, tmp_path, mocker, saved_rate, argv, expected
+    ):
+        """Explicit CLI rates override saved settings, which override the default."""
+        config_file = tmp_path / "s-tui.conf"
+        if saved_rate is not None:
+            config_file.write_text(f"[GraphControl]\nrefresh = {saved_rate}\n")
+
+        mocker.patch("s_tui.s_tui.user_config_dir_exists", return_value=True)
+        mocker.patch("s_tui.s_tui.get_user_config_dir", return_value=str(tmp_path))
+        mocker.patch(
+            "s_tui.s_tui.user_config_file_exists", return_value=config_file.exists()
+        )
+        mocker.patch("s_tui.s_tui.get_user_config_file", return_value=str(config_file))
+        mocker.patch("s_tui.s_tui.ScriptHookLoader")
+        mocker.patch("s_tui.s_tui.GraphView")
+        mocker.patch("s_tui.s_tui.GraphController._config_stress")
+        mocker.patch("s_tui.s_tui.which", return_value=None)
+        for source_name in (
+            "TempSource",
+            "FreqSource",
+            "UtilSource",
+            "RaplPowerSource",
+            "FanSource",
+        ):
+            source = mocker.patch(f"s_tui.s_tui.{source_name}")
+            source.return_value.get_is_available.return_value = False
+
+        mocker.patch.object(sys, "argv", ["s-tui", *argv])
+        controller = GraphController(get_args())
+
+        assert controller.refresh_rate == expected
+        if saved_rate is not None:
+            assert (
+                config_file.read_text() == f"[GraphControl]\nrefresh = {saved_rate}\n"
+            )
+        else:
+            assert not config_file.exists()


### PR DESCRIPTION
With a saved refresh interval of 5 seconds, running `s-tui --refresh-rate 1` still uses 5 seconds. Loading the saved configuration overwrites the command-line value during controller initialization.

This applies the refresh setting in order: the 2-second default, then the saved configuration, then an explicitly supplied command-line value. An omitted option is kept distinct from an explicit `-r 2.0`, so both `-r 1` and `-r 2.0` can override saved settings. The help text now mentions this precedence.

Seven new regression cases exercise the real argument parser and configuration loading, with hardware and the view mocked. They cover saved settings, explicit overrides, no configuration, and malformed saved values. The two override cases fail before the fix; the CLI and configuration tests now pass all 27 cases. Ruff checks pass, and the changed lines and new tests pass Black.

I tested locally on macOS with Python 3.13. The broader test selection has 376 passes, with the same 50 failures/errors present on the original code because macOS psutil lacks the Linux sensor interfaces the tests mock. Hardware and real stress-worker tests were excluded. Pyright also reports 7 existing errors in unchanged urwid-related code. Linux CI and real hardware behavior have not been verified locally.

Fixes #306.
